### PR TITLE
Prevent error when trimming with no trailing space

### DIFF
--- a/lua/whitespace-nvim/init.lua
+++ b/lua/whitespace-nvim/init.lua
@@ -19,7 +19,7 @@ whitespace.highlight = function ()
 end
 
 whitespace.trim = function ()
-  vim.cmd [[%substitute/\v\s+$//g]]
+  vim.cmd [[%substitute/\v\s+$//eg]]
 end
 
 whitespace.setup = function (options)


### PR DESCRIPTION
Vim's `substitute` will error loudly when called if no matches are present.

![image](https://user-images.githubusercontent.com/650603/191405931-1d64cb4e-daf2-413e-81ef-b56dbb189208.png)

`/e` can be used to prevent this and allow multiple calls to `trim()` without causing error messages.