### PR TITLE
Clear previous matches before begin a new match.

### DIFF
--- a/lua/whitespace-nvim/init.lua
+++ b/lua/whitespace-nvim/init.lua
@@ -12,6 +12,8 @@ whitespace.highlight = function ()
     error(string.format('highlight %s does not exist', config.highlight))
   end
 
+  vim.cmd('match')
+
   if config.ignore_terminal and vim.bo.buftype == 'terminal' then
     return
   end


### PR DESCRIPTION
There have a error highlight in dashboard.nvim's buffer, steps to reproduce the problem:
1. type "nvim" to enter dashboard.nvim, whitespace.nvim will igore dashboard buffer correctly
2. type “:e ~/.local/share/nvim/lazy/whitespace.nvim/init.lua” in nvim cmdline, lua will highlight correctly
3. type ":Dashboard" in nvim cmdline will show dashboard.nvim cotents but have error highlight.

because dashboard.nvim show it's content in current buffer but new buffer, so we should clear marches every times.