### PR TITLE
Refine ignore terminal.

### DIFF
--- a/lua/whitespace-nvim/init.lua
+++ b/lua/whitespace-nvim/init.lua
@@ -7,19 +7,13 @@ local config = {
 
 local whitespace = {}
 
+whitespace.clean = function()
+  vim.cmd('match')
+end
+
 whitespace.highlight = function()
   if not vim.fn.hlexists(config.highlight) then
     error(string.format('highlight %s does not exist', config.highlight))
-  end
-
-  vim.cmd('match')
-
-  if config.ignore_terminal and vim.bo.buftype == 'terminal' then
-    return
-  end
-
-  if vim.tbl_contains(config.ignored_filetypes, vim.bo.filetype) then
-    return
   end
 
   local command = string.format([[match %s /\s\+$/]], config.highlight)
@@ -36,15 +30,28 @@ whitespace.trim = function()
   end
 end
 
+local function file_type()
+  if vim.tbl_contains(config.ignored_filetypes, vim.bo.filetype) then
+    whitespace.clean()
+    return
+  end
+  whitespace.highlight()
+end
+
+local function term_open()
+  if config.ignore_terminal then
+    whitespace.clean()
+  else
+    whitespace.highlight()
+  end
+end
+
 whitespace.setup = function(options)
   config = vim.tbl_extend('force', config, options or {})
 
-  vim.cmd [[
-    augroup whitespace_nvim
-      autocmd!
-      autocmd FileType * lua require('whitespace-nvim').highlight()
-    augroup END
-  ]]
+  vim.api.nvim_create_augroup('whitespace_nvim', {clear = true})
+  vim.api.nvim_create_autocmd('FileType', {group = 'whitespace_nvim', pattern = '*', callback = file_type})
+  vim.api.nvim_create_autocmd('TermOpen', {group = 'whitespace_nvim', pattern = '*', callback = term_open})
 end
 
 return whitespace

--- a/lua/whitespace-nvim/init.lua
+++ b/lua/whitespace-nvim/init.lua
@@ -7,7 +7,7 @@ local config = {
 
 local whitespace = {}
 
-whitespace.clean = function()
+whitespace.nohighlight = function()
   vim.cmd('match')
 end
 
@@ -32,15 +32,15 @@ end
 
 local function file_type()
   if vim.tbl_contains(config.ignored_filetypes, vim.bo.filetype) then
-    whitespace.clean()
-    return
+    whitespace.nohighlight()
+  else
+    whitespace.highlight()
   end
-  whitespace.highlight()
 end
 
 local function term_open()
   if config.ignore_terminal then
-    whitespace.clean()
+    whitespace.nohighlight()
   else
     whitespace.highlight()
   end

--- a/lua/whitespace-nvim/init.lua
+++ b/lua/whitespace-nvim/init.lua
@@ -46,12 +46,21 @@ local function term_open()
   end
 end
 
+local function buf_enter()
+  if vim.tbl_contains(config.ignored_filetypes, vim.bo.filetype) or (config.ignore_terminal and vim.bo.buftype == 'terminal' ) then
+    whitespace.nohighlight()
+  else
+    whitespace.highlight()
+  end
+end
+
 whitespace.setup = function(options)
   config = vim.tbl_extend('force', config, options or {})
 
   vim.api.nvim_create_augroup('whitespace_nvim', {clear = true})
   vim.api.nvim_create_autocmd('FileType', {group = 'whitespace_nvim', pattern = '*', callback = file_type})
   vim.api.nvim_create_autocmd('TermOpen', {group = 'whitespace_nvim', pattern = '*', callback = term_open})
+  vim.api.nvim_create_autocmd('BufEnter', {group = 'whitespace_nvim', pattern = '*', callback = buf_enter})
 end
 
 return whitespace


### PR DESCRIPTION
There is a error  highlight on terminal, reproduction steps :
1. cd ~/.local/share/lazy/whitespace.nvim
2. nvim
3. :e lua/whitespace-nvim/init.lua  (in nvim's cmdline)  have a correct highlight
4. :terminal (in nivm's cmdline) have a error highlight

terminal buffer will not set fietype so the "FileType" autocmd will not be excuted , I add a "TermOpen" autocmd to clean match if "ignore_terminal" is set to true, add clean function for user can clean match if they want. and I think we should need put any conditions in hightlignt function , they should be put in function who call them.

please confirm for me , best wishes.